### PR TITLE
Fix taxonomy and term page headings

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -44,7 +44,7 @@ other = "indicates a required field"
 other = "Send"
 
 [taxonomyPageList]
-other = "Below you will find pages that utilize the taxonomy term “{{ .Title }}”"
+other = "List of pages that utilize the taxonomy term “{{ .Title }}”"
 
 [readingTime]
 one = "One minute read"

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,8 +1,5 @@
 {{- define "main" }}
-    <article class="list-article">
-        <p class="main-article-content taxonomy-note">{{ i18n "taxonomyPageList" . }}</p>
-    </article>
-    <section class="articles-summaries">
+    <section class="articles-summaries" aria-label="{{ i18n "taxonomyPageList" . }}">
     {{- range .Pages }}
         {{- .Render "summary-with-image" -}}
     {{- end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -5,8 +5,7 @@
         {{- partial "handle-content" .Content -}}
         </div>
     </article>
-    <section class="main-article terms-block">
-        <h2 class="terms-title">{{ i18n "listOfTitle" | default "List of" }} {{ $data.Plural | humanize | lower }}</h2>
+    <section class="main-article terms-block" aria-label="{{ i18n "listOfTitle" | default "List of" }} {{ $data.Plural | humanize | lower }}">
         <ul class="terms-list">
             {{- range $key, $value := .Data.Terms }}
                 <li class="terms-item"><a class="terms-link" href="{{ (printf "/%s/%s" ($.Data.Plural | urlize) ($key | urlize)) | relLangURL }}">

--- a/layouts/partials/site-header-titles.html
+++ b/layouts/partials/site-header-titles.html
@@ -8,13 +8,7 @@
 {{- end -}}
 {{- if not (or .Params.omit_header_text .Params.headerTextOmit) }}
         <h1 class="{{ $h1Class }}">
-    {{- if not .Data.Singular -}}
-        {{- index $pageMetadata "title-page" -}}
-    {{- else if not .Data.Terms -}}
-        {{ .Data.Singular | humanize }}: {{ index $pageMetadata "title-page" | humanize | title -}}
-    {{- else -}}
-        {{ i18n "taxonomyTitle" | default "Taxonomy" }}: {{ index $pageMetadata "title-page" -}}
-    {{- end -}}
+    {{- index $pageMetadata "title-page" -}}
         </h1>
     {{- with (index $pageMetadata "description-no-fallback") }}
         <h2 class="{{ $h2Class }}">


### PR DESCRIPTION
Due to metadata now properly setting taxonomy and term pages, we need to
avoid doing it a second time here.

Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>